### PR TITLE
MethodParametersSniff doesn't completely exclude $ char

### DIFF
--- a/DotBlue/Sniffs/PhpDoc/MethodParametersSniff.php
+++ b/DotBlue/Sniffs/PhpDoc/MethodParametersSniff.php
@@ -41,7 +41,10 @@ class MethodParametersSniff implements PHP_CodeSniffer_Sniff
 
 		$paramDefinition = $tokens[$stackPtr + 2]['content'];
 
-		if (strpos($paramDefinition, '$') !== FALSE) {
+		$foundProblems = array_filter(explode(' ', $paramDefinition), function ($part) {
+			return strpos($part, '$') === 0;
+		});
+		if ($foundProblems) {
 			$fix = $phpcsFile->addFixableError('Variable names in method\'s DocBlock comments are not allowed.', $stackPtr, 'ParameterName');
 
 			if ($fix) {

--- a/DotBlue/tests/invalid/PhpDocMethodParametersName.php
+++ b/DotBlue/tests/invalid/PhpDocMethodParametersName.php
@@ -13,4 +13,13 @@ class Bar
 	{
 	}
 
+
+
+	/**
+	 * @param  callable ($bar)
+	 */
+	public function bar(callable $foo)
+	{
+	}
+
 }

--- a/DotBlue/tests/valid/PhpDocMethodParametersName.php
+++ b/DotBlue/tests/valid/PhpDocMethodParametersName.php
@@ -13,4 +13,13 @@ class Bar
 	{
 	}
 
+
+
+	/**
+	 * @param  callable ($bar)
+	 */
+	public function bar(callable $foo)
+	{
+	}
+
 }


### PR DESCRIPTION
/cc @vysinsky 

This change allows following syntax:

```php
/**
 * @param  callable ($foo)
 */
public function work(callable $callback)
{
    $callback($this->getFoo());
```
