### PR TITLE
Disabled function call signature sniff

### DIFF
--- a/DotBlue/ruleset.xml
+++ b/DotBlue/ruleset.xml
@@ -20,6 +20,7 @@
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration"/>
         <exclude name="Squiz.WhiteSpace.ScopeClosingBrace"/>
         <exclude name="Squiz.WhiteSpace.FunctionSpacing"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.Indent"/>
     </rule>
 
     <rule ref="Generic.PHP.UpperCaseConstant"/>


### PR DESCRIPTION
It requires multi-line call to be indented in really fucked up way.