### PR TITLE
Disabled another function call signature sniff

### DIFF
--- a/DotBlue/ruleset.xml
+++ b/DotBlue/ruleset.xml
@@ -21,6 +21,7 @@
         <exclude name="Squiz.WhiteSpace.ScopeClosingBrace"/>
         <exclude name="Squiz.WhiteSpace.FunctionSpacing"/>
         <exclude name="PSR2.Methods.FunctionCallSignature.Indent"/>
+        <exclude name="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket"/>
     </rule>
 
     <rule ref="Generic.PHP.UpperCaseConstant"/>


### PR DESCRIPTION
Without this sniff, following syntax is possible:

```php
sprintf('%s - %s',
    $foo,
    $bar
);
```

/cc @vysinsky 