### PR TITLE
Sniff for "2 lines after namespace" is resistant to use for closures

### DIFF
--- a/DotBlue/Sniffs/Namespaces/NamespaceDeclarationSniff.php
+++ b/DotBlue/Sniffs/Namespaces/NamespaceDeclarationSniff.php
@@ -30,7 +30,7 @@ class NamespaceDeclarationSniff extends PSR2_Sniffs_Namespaces_NamespaceDeclarat
 
 		$diff = ($tokens[$next]['line'] - $tokens[$i]['line']);
 
-		$useStatement = $phpcsFile->findNext(T_USE, $i, $phpcsFile->numTokens);
+		$useStatement = $phpcsFile->findNext(T_USE, $i, $phpcsFile->findNext(T_CLASS, $i, $phpcsFile->numTokens));
 
 		if ($useStatement === FALSE) {
 			if ($diff !== 2) {

--- a/DotBlue/tests/invalid/NamespaceDeclarationWithoutUseStatement.php
+++ b/DotBlue/tests/invalid/NamespaceDeclarationWithoutUseStatement.php
@@ -5,4 +5,10 @@ namespace Foo;
 class Bar
 {
 
+	public function foo()
+	{
+		$bar = NULL;
+		return function () use ($bar) {};
+	}
+
 }

--- a/DotBlue/tests/valid/NamespaceDeclarationWithoutUseStatement.php
+++ b/DotBlue/tests/valid/NamespaceDeclarationWithoutUseStatement.php
@@ -6,4 +6,10 @@ namespace Foo;
 class Bar
 {
 
+	public function foo()
+	{
+		$bar = NULL;
+		return function () use ($bar) {};
+	}
+
 }


### PR DESCRIPTION
/cc @vysinsky 

Problem was `use` at closure :). Now it determines if there is `use` statement only up to `class` token.