### PR TITLE
Added sniff to find unused private properties

### DIFF
--- a/DotBlue/Sniffs/Php/UnusedPrivatePropertiesSniff.php
+++ b/DotBlue/Sniffs/Php/UnusedPrivatePropertiesSniff.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DotBlue\Sniffs\Php;
+
+use PHP_CodeSniffer_File;
+use PHP_CodeSniffer_Sniff;
+
+
+class UnusedPrivatePropertiesSniff implements PHP_CodeSniffer_Sniff
+{
+
+	public function register()
+	{
+		return [
+			T_PRIVATE,
+		];
+	}
+
+
+
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+	{
+		$tokens = $phpcsFile->getTokens();
+
+		foreach ($tokens as $key => $token) {
+			if ($token['code'] === T_FUNCTION) {
+				if ($tokens[$key + 2]['content'] === '__get' || $tokens[$key + 2]['content'] === '__set') {
+					return;
+				}
+			}
+		}
+
+		$classDeclaration = $phpcsFile->findNext(T_CLASS, 0);
+		$className = $tokens[$classDeclaration + 2]['content'];
+
+		$isStatic = $tokens[$stackPtr + 2]['code'] === T_STATIC;
+
+		if ($tokens[$stackPtr + 2 + ($isStatic ? 2 : 0)]['code'] === T_FUNCTION) {
+			return;
+		}
+
+		$propertyName = substr($tokens[$stackPtr + 2 + ($isStatic ? 2 : 0)]['content'], ($isStatic ? 0 : 1));
+		$isUnused = TRUE;
+
+		$thisAliases = ['$this'];
+
+		if ($isStatic) {
+			$thisAliases[] = 'self';
+			$thisAliases[] = $className;
+		}
+
+		foreach ($tokens as $key => $token) {
+			if ($token['code'] === T_EQUAL) {
+				if (in_array($tokens[$key + 2]['content'], $thisAliases)) {
+					$thisAliases[] = $tokens[$key - 2]['content'];
+				}
+			}
+		}
+
+		$checkOperator = $isStatic ? T_PAAMAYIM_NEKUDOTAYIM : T_OBJECT_OPERATOR;
+
+		foreach ($tokens as $key => $token) {
+			if ($token['code'] === $checkOperator && in_array($tokens[$key - 1]['content'], $thisAliases)) {
+				if ($tokens[$key + 1]['content'] === $propertyName) {
+					$isUnused = FALSE;
+				}
+			}
+		}
+
+		if ($isUnused) {
+			if ($isStatic) {
+				$phpcsFile->addError(sprintf('Found unused private static property \'%s\'. You should remove it.', $propertyName), $stackPtr);
+			} else {
+				$phpcsFile->addError(sprintf('Found unused private property \'$%s\'. You should remove it.', $propertyName), $stackPtr);
+			}
+		}
+	}
+
+}

--- a/DotBlue/tests/UnusedPrivateProperties.phpt
+++ b/DotBlue/tests/UnusedPrivateProperties.phpt
@@ -1,0 +1,32 @@
+<?php
+
+use DotBlue\CodeSniffer\Helpers\Tester;
+
+
+require __DIR__ . '/bootstrap.php';
+
+$tester = new Tester();
+$tester->setFile('UnusedPrivateProperties')
+	->setSniff('Php.UnusedPrivateProperties')
+	->expectMessage('Found unused private property \'$bar\'. You should remove it.')
+	->onLine(11);
+
+$tester->setFile('UnusedPrivatePropertiesWithAliasedThis')
+	->setSniff('Php.UnusedPrivateProperties')
+	->expectMessage('Found unused private property \'$bar\'. You should remove it.')
+	->onLine(11);
+
+$tester->setFile('UnusedPrivateStaticProperties')
+	->setSniff('Php.UnusedPrivateProperties')
+	->expectMessage('Found unused private static property \'$bar\'. You should remove it.')
+	->onLine(11);
+
+$tester->setFile('UnusedPrivatePropertiesMagicMethods')
+	->setSniff('Php.UnusedPrivateProperties')
+	->doNotExpectMessage('Found unused private property \'$x\'. You should remove it.')
+	->onLine(6)
+	->getFile()
+	->expectMessage('Found unused private property \'$x\'. You should remove it.')
+	->onLine(6);
+
+$tester->test();

--- a/DotBlue/tests/invalid/UnusedPrivateProperties.php
+++ b/DotBlue/tests/invalid/UnusedPrivateProperties.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Foo;
+
+
+class Foo
+{
+
+	private $foo;
+
+	private $bar;
+
+
+
+	public function foo()
+	{
+		$this->foo = 'bar';
+	}
+
+}

--- a/DotBlue/tests/invalid/UnusedPrivatePropertiesMagicMethods.php
+++ b/DotBlue/tests/invalid/UnusedPrivatePropertiesMagicMethods.php
@@ -1,0 +1,8 @@
+<?php
+
+class Coordinates
+{
+
+	private $x;
+
+}

--- a/DotBlue/tests/invalid/UnusedPrivatePropertiesWithAliasedThis.php
+++ b/DotBlue/tests/invalid/UnusedPrivatePropertiesWithAliasedThis.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Foo;
+
+
+class Foo
+{
+
+	private $foo;
+
+	private $bar;
+
+	public function foo()
+	{
+		$that = $this;
+		$foo = $that;
+		$foo->foo = 'bar';
+	}
+
+}

--- a/DotBlue/tests/invalid/UnusedPrivateStaticProperties.php
+++ b/DotBlue/tests/invalid/UnusedPrivateStaticProperties.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Foo;
+
+
+class Foo
+{
+
+	private static $foo;
+
+	private static $bar;
+
+
+
+	public function foo()
+	{
+		self::$foo = 'bar';
+	}
+
+
+
+	private static function bar()
+	{
+
+	}
+
+}

--- a/DotBlue/tests/valid/UnusedPrivateProperties.php
+++ b/DotBlue/tests/valid/UnusedPrivateProperties.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Foo;
+
+
+class Foo
+{
+
+	private $foo;
+
+
+
+	public function foo()
+	{
+		$this->foo = 'bar';
+	}
+
+}

--- a/DotBlue/tests/valid/UnusedPrivatePropertiesMagicMethods.php
+++ b/DotBlue/tests/valid/UnusedPrivatePropertiesMagicMethods.php
@@ -1,0 +1,14 @@
+<?php
+
+class Coordinates
+{
+
+	private $x;
+
+
+
+	public function __get($name)
+	{
+		return $this->$name;
+	}
+}

--- a/DotBlue/tests/valid/UnusedPrivatePropertiesWithAliasedThis.php
+++ b/DotBlue/tests/valid/UnusedPrivatePropertiesWithAliasedThis.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Foo;
+
+
+class Foo
+{
+
+	private $foo;
+
+
+
+	public function foo()
+	{
+		$that = $this;
+		$bar = $that;
+		$bar->foo = 'bar';
+	}
+
+}

--- a/DotBlue/tests/valid/UnusedPrivateStaticProperties.php
+++ b/DotBlue/tests/valid/UnusedPrivateStaticProperties.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Foo;
+
+
+class Foo
+{
+
+	private static $foo;
+
+	private static $bar;
+
+	public function foo()
+	{
+		self::$foo = 'bar';
+	}
+
+
+
+	private static function bar()
+	{
+		Foo::$bar = NULL;
+	}
+
+}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Differences from PSR-2
 - Disabled absolute namespace usage. Import everything with 'use' statement
 - There must be exactly one space between `&` and variable name
 - Forbidden calls of functions `d`, `dump`, `var_dump`
+- Ruleset can find unused private properties
+	- even with aliased $this
+	- even static properties (self::, ClassName::)
 
 Generating documentation
 ------------------------


### PR DESCRIPTION
Closes #29 
I am really proud on this sniff :)

- it detects unused private properties
- it detects them even if you alias `$this` - it will not mark them as unused
- it works correctly also with static properties - no matter if you use `self::` or `ClassName::`

/cc @vojtech-dobes 